### PR TITLE
Fix for Mac: replace all instances of modal dialog Hide() with EndModal(0).

### DIFF
--- a/src/whacked4/ui/dialogs/aboutdialog.py
+++ b/src/whacked4/ui/dialogs/aboutdialog.py
@@ -23,7 +23,7 @@ class AboutDialog(windows.AboutDialogBase):
             self.license_text = f.read()
 
     def ok(self, event):
-        self.Hide()
+        self.EndModal(0)
 
     def license(self, event):
         wx.MessageBox(message=self.license_text, caption='License', style=wx.OK, parent=self)

--- a/src/whacked4/ui/dialogs/errordialog.py
+++ b/src/whacked4/ui/dialogs/errordialog.py
@@ -35,4 +35,4 @@ class ErrorDialog(windows.ErrorDialogBase):
         self.Report.SetSelection(-1, -1)
 
     def close(self, event):
-        self.Hide()
+        self.EndModal(0)

--- a/src/whacked4/ui/dialogs/patchinfodialog.py
+++ b/src/whacked4/ui/dialogs/patchinfodialog.py
@@ -126,7 +126,7 @@ class PatchInfoDialog(windows.PatchInfoDialogBase):
             self.selected_iwad = None
         self.selected_pwads = self.pwads
 
-        self.Hide()
+        self.EndModal(0)
 
     def delete_iwad(self, event):
         """
@@ -193,4 +193,4 @@ class PatchInfoDialog(windows.PatchInfoDialogBase):
             self.PWADList.DeleteItem(index)
 
     def cancel(self, event):
-        self.Hide()
+        self.EndModal(0)

--- a/src/whacked4/ui/dialogs/spritesdialog.py
+++ b/src/whacked4/ui/dialogs/spritesdialog.py
@@ -51,7 +51,7 @@ class SpritesDialog(windows.SpritesDialogBase):
             else:
                 self.selected_frame = int(frame_index)
 
-        self.Hide()
+        self.EndModal(0)
 
     def sprite_select_list(self, event):
         """
@@ -213,7 +213,7 @@ class SpritesDialog(windows.SpritesDialogBase):
         event.Skip()
 
     def cancel(self, event):
-        self.Hide()
+        self.EndModal(0)
 
     def filter_update(self, event):
         window = self.FindWindowById(event.GetId())

--- a/src/whacked4/ui/dialogs/startdialog.py
+++ b/src/whacked4/ui/dialogs/startdialog.py
@@ -30,17 +30,17 @@ class StartDialog(windows.StartDialogBase):
         Opens a Dehacked patch directly from the file list.
         """
 
-        self.Hide()
+        self.EndModal(0)
         filename = config.settings['recent_files'][event.GetIndex()]
         self.GetParent().open_file(filename)
 
     def new_file(self, event):
-        self.Hide()
+        self.EndModal(0)
         self.GetParent().new_file()
 
     def open_file(self, event):
-        self.Hide()
+        self.EndModal(0)
         self.GetParent().open_file_dialog()
 
     def cancel(self, event):
-        self.Hide()
+        self.EndModal(0)

--- a/src/whacked4/ui/dialogs/stringdialog.py
+++ b/src/whacked4/ui/dialogs/stringdialog.py
@@ -118,8 +118,8 @@ class StringDialog(windows.StringDialogBase):
 
     def ok(self, event):
         self.new_string = self.New.GetValue()
-        self.Hide()
+        self.EndModal(0)
 
     def cancel(self, event):
         self.new_string = None
-        self.Hide()
+        self.EndModal(0)

--- a/src/whacked4/ui/editormixin.py
+++ b/src/whacked4/ui/editormixin.py
@@ -119,6 +119,8 @@ class EditorMixin(wx.Frame):
         """
 
         window = self.GetParent().FindWindowById(event.GetId())
+        if window is None:
+            return
         window.SetCursor(wx.StockCursor(wx.CURSOR_HAND))
         window.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHT))
         window.Refresh()
@@ -129,6 +131,8 @@ class EditorMixin(wx.Frame):
         """
 
         window = self.GetParent().FindWindowById(event.GetId())
+        if window is None:
+            return
         window.SetCursor(wx.StockCursor(wx.CURSOR_ARROW))
         window.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOWTEXT))
         window.Refresh()

--- a/src/whacked4/ui/editors/thingsframe.py
+++ b/src/whacked4/ui/editors/thingsframe.py
@@ -248,11 +248,15 @@ class ThingsFrame(editormixin.EditorMixin, windows.ThingsFrameBase):
         Resizes the thing name column to match the control's width.
         """
 
-        columns_width = self.ThingList.GetColumnWidth(0)
-        columns_width += self.ThingList.GetColumnWidth(2) + self.ThingList.GetColumnWidth(3)
+        # ioanch 20160124: check bounds
+        col_count = self.ThingList.GetColumnCount()
+        columns_width = self.ThingList.GetColumnWidth(0) if col_count > 0 else 0
+        if col_count > 3:
+            columns_width += self.ThingList.GetColumnWidth(2) + self.ThingList.GetColumnWidth(3)
 
         width = self.ThingList.GetClientSizeTuple()[0] - columns_width - 4
-        self.ThingList.SetColumnWidth(1, width)
+        if col_count > 1:
+            self.ThingList.SetColumnWidth(1, width)
 
     def flaglist_build(self):
         """

--- a/src/whacked4/ui/editors/weaponsframe.py
+++ b/src/whacked4/ui/editors/weaponsframe.py
@@ -129,10 +129,10 @@ class WeaponsFrame(editormixin.EditorMixin, windows.WeaponsFrameBase):
         """
         Resizes the weapon list to fill as much space as is available.
         """
-
-        column_width = self.WeaponList.GetClientSizeTuple()[0] - 4
-        self.WeaponList.SetColumnWidth(0, column_width / 2)
-        self.WeaponList.SetColumnWidth(1, column_width / 2)
+        if self.WeaponList.GetColumnCount() > 1:
+            column_width = self.WeaponList.GetClientSizeTuple()[0] - 4
+            self.WeaponList.SetColumnWidth(0, column_width / 2)
+            self.WeaponList.SetColumnWidth(1, column_width / 2)
 
     def ammolist_build(self):
         """


### PR DESCRIPTION
They would never return out of ShowModal, even if the dialogs were closed/hidden, so the program would become unresponsive.

__Unless these changes are obviously correct, please test this before merging, because I didn't have time to verify it on Windows__