### PR TITLE
Add IWAD detection for chex.wad and chex3.wad (official version).

### DIFF
--- a/src/whacked4/doom/wad.py
+++ b/src/whacked4/doom/wad.py
@@ -101,6 +101,10 @@ class WADReader(object):
                 self.lumps.append(Lump(name, size, offset, self))
 
         self.filename = filename
+        # chex[3].wad detection.
+        if (wad_type == self.TYPE_PWAD and self.get_lump('E1M1') and self.get_lump('E3M1')
+        and self.get_lump('W94_1') and self.get_lump('POSSH0M0')):
+            wad_type = self.TYPE_IWAD
         self.type = wad_type
 
     def get_lump(self, lump_name):


### PR DESCRIPTION
Currently, chex.wad and chex3.wad (official version, not to be confused with a fan-made WAD from around 2000) aren't detected as IWADs by WhackEd4, forcing users making DeHackEd or BEX patches for those IWADs to use (or buy) a commercial IWAD.

This is due to the fact that the only way WhackEd4 checks for IWADs is for the IWAD identifier placed as plain text in the beginning of WAD files. However, most modern WAD editors (including those used by Digital Cafe in 1996) use the PWAD tag by default, creating IWADs with the PWAD tag. This is not a reliable means to check whether something is an IWAD or not.

This patch addresses issue #38.